### PR TITLE
Add filename(s) to trigger_dag configuration

### DIFF
--- a/unaflow/dags/trigger_dag/providers/google/gcs_trigger_dag_configuration.py
+++ b/unaflow/dags/trigger_dag/providers/google/gcs_trigger_dag_configuration.py
@@ -61,7 +61,8 @@ class GcsMovefilesTriggerDagConfiguration(TriggerDagConfiguration):
             self.configuration = {**self.configuration, 'filename': XCOM_TOP_FILE}
         else:
             self._source_objects = f"{{{{ ti.xcom_pull(task_ids='{SENSOR_TASK_ID}') }}}}"
-            self.configuration = {**self.configuration, 'filenames': f"{{{{ ti.xcom_pull(task_ids='{SENSOR_TASK_ID}') }}}}"}
+            self.configuration = {**self.configuration,
+                                  'filenames': f"{{{{ ti.xcom_pull(task_ids='{SENSOR_TASK_ID}') }}}}"}
 
     def create_sensor(self) -> BaseSensorOperator:
         return GCSObjectsWithPrefixExistenceSensor(

--- a/unaflow/dags/trigger_dag/providers/google/gcs_trigger_dag_configuration.py
+++ b/unaflow/dags/trigger_dag/providers/google/gcs_trigger_dag_configuration.py
@@ -58,8 +58,10 @@ class GcsMovefilesTriggerDagConfiguration(TriggerDagConfiguration):
         self.single_file = single_file
         if self.single_file:
             self._source_objects = [XCOM_TOP_FILE]
+            self.configuration = {**self.configuration, 'filename': XCOM_TOP_FILE}
         else:
             self._source_objects = f"{{{{ ti.xcom_pull(task_ids='{SENSOR_TASK_ID}') }}}}"
+            self.configuration = {**self.configuration, 'filenames': f"{{{{ ti.xcom_pull(task_ids='{SENSOR_TASK_ID}') }}}}"}
 
     def create_sensor(self) -> BaseSensorOperator:
         return GCSObjectsWithPrefixExistenceSensor(


### PR DESCRIPTION
Missing from 0.4 versions was that we supplied the dag_conf filename and filenames when using GCS Configuration. This adds it back, when using Airflow 2.