### PR TITLE
Use AirFlow 2.10.5

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set-up python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11.9
 
       - name: Create cache
         id: cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-apache-airflow==2.2.5
-apache-airflow-providers-google==6.7.0
+apache-airflow==2.10.5
+apache-airflow-providers-google==15.1.0
 # Testing
-pytest==5.3.5
+pytest==8.3.5
 flake8==4.0.1
 # Versioning and release
 versioneer==0.18

--- a/unaflow/dags/trigger_dag/trigger_dag_configuration.py
+++ b/unaflow/dags/trigger_dag/trigger_dag_configuration.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from typing import Dict, Optional, Sequence, Union
 
 from airflow.models.taskmixin import TaskMixin
-from airflow.models.baseoperator import TaskStateChangeCallback
+from airflow.models.abstractoperator import TaskStateChangeCallback
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils import timezone
 

--- a/unaflow/dags/trigger_dag/trigger_dag_configuration.py
+++ b/unaflow/dags/trigger_dag/trigger_dag_configuration.py
@@ -3,7 +3,13 @@ from datetime import timedelta
 from typing import Dict, Optional, Sequence, Union
 
 from airflow.models.taskmixin import TaskMixin
-from airflow.models.abstractoperator import TaskStateChangeCallback
+
+try:
+    from airflow.models.abstractoperator import TaskStateChangeCallback
+except ImportError:
+    # For Airflow versions < 2.7.0
+    from airflow.models.baseoperator import TaskStateChangeCallback
+
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils import timezone
 


### PR DESCRIPTION
<!-- Why gherkin? https://cucumber.io/docs/gherkin/reference/ -->

```gherkin
As a developer
I want to upgrade dependencies that match AirFlow 2.10.5
So that i can use module as dependency for other upgraded modules 
```
